### PR TITLE
Browserify Transform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ grunt.initConfig({
 });
 ```
 
+## Using as browserify transform
+
+```javascript
+browserify:     {
+    options:      {
+        transform:  [ require('grunt-prepr').browserify(["DEBUG"]) ],
+    }
+}
+```
+
 ## Examples
 
 For more details, refer to the [examples](https://github.com/antivanov/grunt-prepr/tree/master/examples) in the repository and Jasmine [specs](https://github.com/antivanov/grunt-prepr/tree/master/spec).

--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+/**
+ * Created by chaika on 20.03.16.
+ */
+var prepr = require("./src/prepr")
+var through = require('through');
+exports.browserify = function(defined) {
+    return function(file) {
+        var data = '';
+        return through(function(buf) {
+            data += buf;
+        }, function() {
+            var self = this;
+
+            var preprocessedFileContents = prepr.preprocess(data, defined);
+            self.queue(preprocessedFileContents);
+            self.queue(null);
+        });
+    }
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Grunt preprocessor plugin",
   "version": "0.1.0",
   "homepage": "https://github.com/antivanov/grunt-prepr",
+  "main": "index.js",
   "author": {
     "name": "Anton Ivanov",
     "url": "https://github.com/antivanov"
@@ -28,7 +29,7 @@
   },
   "dependencies": {
     "through": "^2.3.8"
-  },  
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.1",
     "grunt-contrib-jasmine": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "scripts": {
     "test": "grunt jasmine:unit"
   },
+  "dependencies": {
+    "through": "^2.3.8"
+  },  
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.1",
     "grunt-contrib-jasmine": "~0.5.1",

--- a/tasks/prepr-grunt.js
+++ b/tasks/prepr-grunt.js
@@ -1,7 +1,6 @@
 var prepr = require("../src/prepr"),
     fs = require("fs"),
     path = require("path");
-var through = require('through');
 
 module.exports = function(grunt) {
 
@@ -29,19 +28,4 @@ module.exports = function(grunt) {
             }
         });
     });
-};
-
-exports.browserify = function(defined) {
-    return function(file) {
-        var data = '';
-        return through(function(buf) {
-            data += buf;
-        }, function() {
-            var self = this;
-
-            var preprocessedFileContents = prepr.preprocess(data, defined);
-            self.queue(preprocessedFileContents);
-            self.queue(null);
-        });
-    }
 };

--- a/tasks/prepr-grunt.js
+++ b/tasks/prepr-grunt.js
@@ -1,6 +1,7 @@
 var prepr = require("../src/prepr"),
     fs = require("fs"),
     path = require("path");
+var through = require('through');
 
 module.exports = function(grunt) {
 
@@ -28,4 +29,19 @@ module.exports = function(grunt) {
             }
         });
     });
+};
+
+exports.browserify = function(defined) {
+    return function(file) {
+        var data = '';
+        return through(function(buf) {
+            data += buf;
+        }, function() {
+            var self = this;
+
+            var preprocessedFileContents = prepr.preprocess(data, defined);
+            self.queue(preprocessedFileContents);
+            self.queue(null);
+        });
+    }
 };


### PR DESCRIPTION
You can now use the prepr as the browserify transform, which will transform all files on fly.

``` javascript
browserify:     {
    options:      {
        transform:  [ require('grunt-prepr').browserify(["DEBUG"]) ],
    }
}
```
